### PR TITLE
Fix java installed version check

### DIFF
--- a/firefox-plugins-installer
+++ b/firefox-plugins-installer
@@ -35,6 +35,9 @@ exit_with_error() {
 # Data needed for the Java plugin
 JAVA_BUILD=8u121-b13
 JAVA_VERSION=`echo ${JAVA_BUILD} | cut -f 1 -d -`
+JAVA_FAMILY=`echo ${JAVA_VERSION} | cut -f 1 -d u`
+JAVA_UPDATE=`echo ${JAVA_VERSION} | cut -f 2 -d u`
+JAVA_JRE_VERSION=1.${JAVA_FAMILY}.0_${JAVA_UPDATE}
 JAVA_FILENAME=jre-${JAVA_VERSION}-linux-x64.tar.gz
 JAVA_FILE_PATH=${CACHE_DIR}/${JAVA_FILENAME}
 JAVA_URL_HASH=e9e7ea248e2c4826b92b3f075a80e441
@@ -251,7 +254,7 @@ flash_finish
 if [ ! -e ${JAVA_LINK} ]; then
     echo "JAVA is not correctly installed for Firefox"
 
-    java_plugin=`ls ${JAVA_DIR}/jre*/lib/amd64/libnpjp2.so 2>/dev/null` || echo ""
+    java_plugin=`ls ${JAVA_DIR}/jre${JAVA_JRE_VERSION}/lib/amd64/libnpjp2.so 2>/dev/null` || echo ""
     if [ ! -e "${java_plugin}" ]; then
         download_java
         install_java


### PR DESCRIPTION
Previously, we accepted any installed version to skip
the installation step.  But now that we want to be able
to update the version, we should check if exactly the
specified version is installed.

https://phabricator.endlessm.com/T15963