### PR TITLE
Add access to the codecs libs

### DIFF
--- a/org.mozilla.Firefox.json.in
+++ b/org.mozilla.Firefox.json.in
@@ -12,6 +12,8 @@
     "--socket=pulseaudio",
     "--share=network",
     "--filesystem=home",
+    "--filesystem=/var/lib/codecs:ro",
+    "--env=LD_LIBRARY_PATH=/var/lib/codecs:/app/lib",
     "--talk-name=org.gnome.GConf",
     "--extra-data=firefox.tar.bz2:33a854915df70646d83a191fbad864a539bfd52b7d82e8f58e05abbbf5408dde:57773849::https://archive.mozilla.org/pub/firefox/releases/52.0.1esr/linux-x86_64/en-US/firefox-52.0.1esr.tar.bz2",
     "--extra-data=ach.xpi:239427180c36b96e3a153f987058463f3a96488835601f3b5e113460b478c056:427640::https://archive.mozilla.org/pub/firefox/releases/52.0.1esr/linux-x86_64/xpi/ach.xpi",


### PR DESCRIPTION
Firefox only supports MP4 H264 if there is a 3rd party decoder
available. So we need to make sure that the codecs' path in EOS are
accessible to it.

https://phabricator.endlessm.com/T16381