### PR TITLE
Add --device=all to allow access to webcams

### DIFF
--- a/org.mozilla.Firefox.json
+++ b/org.mozilla.Firefox.json
@@ -16,6 +16,7 @@
         "--filesystem=home",
         "--talk-name=org.gnome.vfs.*",
         "--device=dri",
+        "--device=all",
         "--filesystem=xdg-run/dconf",
         "--filesystem=xdg-config/dconf:ro",
         "--talk-name=ca.desrt.dconf",


### PR DESCRIPTION
We do not live in the era of Pipewire, yet, so Firefox needs direct
device access to show my face to the world.

https://phabricator.endlessm.com/T22543