### PR TITLE
Temporarily disable flash extension

### DIFF
--- a/org.mozilla.Firefox.json
+++ b/org.mozilla.Firefox.json
@@ -28,13 +28,6 @@
         "--talk-name=org.freedesktop.ScreenSaver",
         "--talk-name=org.gtk.vfs.*"
     ],
-    "add-extensions": {
-        "com.adobe.FlashPlayer.NPAPI": {
-            "add-ld-path": "lib",
-            "directory": "firefox/flash",
-            "autodelete": true
-        }
-    },
     "modules": [
         "shared-modules/gtk2/gtk2.json",
         {


### PR DESCRIPTION
This is an attempt to fix an issue with gnome-software failing when
upgrading from a prev firefox version.
Given that the flash extension depends on flatpak >= 1.4.2 and we
don't ship that yet, lets disable the extension for now.

Flash support should still work but using the firefox-plugins-installer
script.

https://phabricator.endlessm.com/T22543

Signed-off-by: Andre Moreira Magalhaes <andre@endlessm.com>