### PR TITLE
Do not auto-download flash extension

### DIFF
--- a/org.mozilla.Firefox.json
+++ b/org.mozilla.Firefox.json
@@ -32,7 +32,8 @@
         "com.adobe.FlashPlayer.NPAPI": {
             "add-ld-path": "lib",
             "directory": "firefox/flash",
-            "autodelete": true
+            "autodelete": true,
+            "no-autodownload": true
         }
     },
     "modules": [


### PR DESCRIPTION
This is an attempt to fix an issue with gnome-software failing when
upgrading from a prev firefox version.
Given that the flash extension depends on flatpak >= 1.4.2 and we
don't ship that yet, lets disable its auto downloading for now.

Flash support should still work but using the firefox-plugins-installer
script or by manually installing the extension.

https://phabricator.endlessm.com/T22543

Signed-off-by: Andre Moreira Magalhaes <andre@endlessm.com>