### PR TITLE
Add external data checker metadata for firefox extra-data

### DIFF
--- a/org.mozilla.Firefox.json
+++ b/org.mozilla.Firefox.json
@@ -67,6 +67,9 @@
                 "install -Dm 644 -t /app/firefox/data endless-default-prefs.js",
                 "install -Dm 644 -t /app/firefox/data distribution.ini"
             ],
+            "x-checker-data": {
+                "type": "firefox"
+            },
             "sources": [
                 {
                     "type": "file",


### PR DESCRIPTION
Depends on https://github.com/endlessm/flatpak-external-data-checker/pull/28.

https://phabricator.endlessm.com/T21208

