### PR TITLE
Add a policies.json to disable auto updates

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -6,7 +6,7 @@ rm firefox.tar.bz2
 ln -s /app/firefox/plugins firefox/browser
 
 mkdir -p firefox/{distribution/extensions,browser/defaults/preferences}
-ln -s /app/firefox/data/distribution.ini firefox/distribution
+ln -s /app/firefox/data/{distribution.ini,policies.json} firefox/distribution
 ln -s /app/firefox/data/endless-default-prefs.js firefox/browser/defaults/preferences
 
 for xpi in *.xpi; do

--- a/org.mozilla.Firefox.json
+++ b/org.mozilla.Firefox.json
@@ -65,7 +65,8 @@
                 "install -Dm 644 -t /app/share/applications org.mozilla.Firefox.desktop",
                 "for size in 16 32 48 64 128; do install -D -m644 icons/default${size}.png /app/share/icons/hicolor/${size}x${size}/apps/org.mozilla.Firefox.png; done",
                 "install -Dm 644 -t /app/firefox/data endless-default-prefs.js",
-                "install -Dm 644 -t /app/firefox/data distribution.ini"
+                "install -Dm 644 -t /app/firefox/data distribution.ini",
+                "install -Dm 644 -t /app/firefox/data policies.json"
             ],
             "sources": [
                 {
@@ -90,11 +91,15 @@
                 },
                 {
                     "type": "file",
+                    "path": "endless-default-prefs.js"
+                },
+                {
+                    "type": "file",
                     "path": "distribution.ini"
                 },
                 {
                     "type": "file",
-                    "path": "endless-default-prefs.js"
+                    "path": "policies.json"
                 },
                 {
                     "type": "dir",

--- a/policies.json
+++ b/policies.json
@@ -1,0 +1,6 @@
+{
+  "policies": {
+    "DisableAppUpdate": true,
+    "DontCheckDefaultBrowser": true
+  }
+}


### PR DESCRIPTION
I tried several other ways to turn off auto-update prompts, to no avail. The con is that we end up with a persistent display that shows it's being managed via a policies file:

![Screenshot from 2019-08-16 18-09-14](https://user-images.githubusercontent.com/1690697/63218105-1d370900-c119-11e9-87b0-b5fc5a1aee81.png)

I'm guessing the options dying is related to [this](https://www.ghacks.net/2018/07/28/mozilla-makes-it-more-difficult-to-block-firefox-updates/)?